### PR TITLE
Rebuild for new compilers (again)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 70bd5675abb3d4a555dac02516fef2156ae116e6f68f4e35901097b53b173b25
 
 build:
-  number: 1000
+  number: 2000
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Due to an issue in ci-scripts, which has been resolved, there was a bad version
number bump in the main channel for this package.

This PR will increase the build number for the new compiler's build by 1000,
allowing them to take precedence when the new compilers are merged with the
main branch.